### PR TITLE
Update GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,11 @@ jobs:
   ci:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
@@ -36,11 +36,11 @@ jobs:
     permissions:
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm


### PR DESCRIPTION
## Summary
This PR updates the GitHub Actions workflow dependencies to their latest major versions to ensure compatibility with current tooling and security best practices.

## Key Changes
- Updated `actions/checkout` from v4 to v6
- Updated `pnpm/action-setup` from v4 to v5
- Updated `actions/setup-node` from v4 to v6

These updates are applied consistently across both the `ci` and `release` jobs in the workflow.

## Details
These version bumps bring improvements in performance, security, and compatibility with Node.js 24 (which is already specified in the workflow configuration). The updates ensure the CI/CD pipeline uses the latest stable versions of these critical GitHub Actions.

https://claude.ai/code/session_01DjKgLCoX8EpmLjeFZWMGgf